### PR TITLE
Fix detection of moc for Qt5

### DIFF
--- a/poppler/configure.ac
+++ b/poppler/configure.ac
@@ -661,20 +661,20 @@ if test x$enable_poppler_qt5 = xyes; then
   AC_CHECK_TOOL(MOCQT5, moc)
   AC_MSG_CHECKING([for Qt5 moc])
   mocversion=`$MOCQT5 -v 2>&1`
-  mocversiongrep=`echo $mocversion | grep "Qt 5"`
+  mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
   if test x"$mocversiongrep" != x"$mocversion"; then
     AC_MSG_RESULT([no])
     # moc was not the qt5 one, try with moc-qt5
     AC_CHECK_TOOL(MOCQT52, moc-qt5)
     AC_MSG_CHECKING([for Qt5 moc-qt5])
     mocversion=`$MOCQT52 -v 2>&1`
-    mocversiongrep=`echo $mocversion | grep "Qt 5"`
+    mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
     if test x"$mocversiongrep" != x"$mocversion"; then
       AC_CHECK_TOOL(QTCHOOSER, qtchooser)
       AC_MSG_CHECKING([for qtchooser])
       qt5tooldir=`QT_SELECT=qt5 qtchooser -print-env | grep QTTOOLDIR | cut -d '=' -f 2 | cut -d \" -f 2`
       mocversion=`$qt5tooldir/moc -v 2>&1`
-      mocversiongrep=`echo $mocversion | grep "Qt 5"`
+      mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
       if test x"$mocversiongrep" != x"$mocversion"; then
         # no valid moc found
         enable_poppler_qt5=no;


### PR DESCRIPTION
Bug #72744

On my Mac OS X 10.9 Mavericks system with Qt 5.2.0 installed using
Homebrew, the output of the moc command doesn't include the string
"Qt 5" which is expected by the moc version detection logic in
configure.ac of poppler 0.24.4. This patch updates the grep pattern so
that the current expected moc version output and the version output of
this installation of Qt5 are both detected as a valid moc for Qt5. With
this patch applied, I was able to build and test poppler with Qt5
support successfully.

(09:26:05)(tj@gauri)(~)$ uname -a
Darwin gauri.ad.local.domain 13.0.0 Darwin Kernel Version 13.0.0: Thu Sep 19 22:22:27 PDT 2013; root:xnu-2422.1.72~6/RELEASE_X86_64 x86_64 i386 MacBookPro3,1 Darwin
(09:26:08)(tj@gauri)(~)$ /usr/local/opt/qt5/bin/moc -v
moc 5.2.0
(09:26:24)(tj@gauri)(~)$
