### PR TITLE
Don't segfault on malformed segments.

### DIFF
--- a/poppler/poppler/JBIG2Stream.cc
+++ b/poppler/poppler/JBIG2Stream.cc
@@ -1495,7 +1495,7 @@ void JBIG2Stream::readSegments() {
 	// arithmetic-coded symbol dictionary segments when numNewSyms
 	// == 0.  Segments like this often occur for blank pages.
 	
-	error(errSyntaxError, curStr->getPos(), "{0:d} extraneous byte{1:s} after segment",
+	error(errSyntaxError, curStr->getPos(), "{0:lld} extraneous byte{1:s} after segment",
 	      segExtraBytes, (segExtraBytes > 1) ? "s" : "");
 	
 	// Burn through the remaining bytes -- inefficient, but


### PR DESCRIPTION
I believe this patch, originated from http://cgit.freedesktop.org/poppler/poppler/commit/?h=poppler-0.24&id=58e04a08afee39370283c494ee2e4e392fd3b684 corrects the crashes reported on TJC at https://together.jolla.com/question/22721/some-pdfs-crash-documents/

In the TJC thread, there is a PDF document that currently makes the sailfish-office document viewer crashes. After patch applied, the document can be read.