### PR TITLE
Upgrade to upstream 0.24.5

### DIFF
--- a/poppler/CMakeLists.txt
+++ b/poppler/CMakeLists.txt
@@ -18,7 +18,7 @@ CHECK_FILE_OFFSET_BITS()
 
 set(POPPLER_MAJOR_VERSION "0")
 set(POPPLER_MINOR_VERSION "24")
-set(POPPLER_MICRO_VERSION "0")
+set(POPPLER_MICRO_VERSION "5")
 set(POPPLER_VERSION "${POPPLER_MAJOR_VERSION}.${POPPLER_MINOR_VERSION}.${POPPLER_MICRO_VERSION}")
 
 # command line switches
@@ -423,7 +423,7 @@ add_library(poppler STATIC ${poppler_SRCS})
 else(MSVC)
 add_library(poppler SHARED ${poppler_SRCS})
 endif(MSVC)
-set_target_properties(poppler PROPERTIES VERSION 43.0.0 SOVERSION 43)
+set_target_properties(poppler PROPERTIES VERSION 44.0.0 SOVERSION 44)
 target_link_libraries(poppler ${poppler_LIBS})
 target_link_libraries(poppler LINK_INTERFACE_LIBRARIES "")
 install(TARGETS poppler RUNTIME DESTINATION bin LIBRARY DESTINATION lib${LIB_SUFFIX} ARCHIVE DESTINATION lib${LIB_SUFFIX})

--- a/poppler/NEWS
+++ b/poppler/NEWS
@@ -1,3 +1,70 @@
+Release 0.24.5
+        core:
+         * Fix crash due to wrong formatting of error message. KDE Bug #328511
+
+Release 0.24.4
+        core:
+         * Fix regression in broken endstream detection. Bug #70854
+         * Catalog: sort entries of NameTrees to make sure lookup works. Bug #26049
+         * Don't infinite loop if reading from GooFile::read fails. Bug #71835
+
+        utils:
+         * pdftotext: Do not close stdout. Bug #71639
+         * pdftotext: Silence warning for may be used uninitialized variable. Bug #71640
+         * pdftotext: Escape the text of the xml headers
+         * Warn the user if he provides a wrong range
+
+        qt4:
+         * Fix typo in xml API. Bug #71643
+
+        qt5:
+         * Fix typo in xml API. Bug #71643
+
+Release 0.24.3
+        core:
+         * PSOutputDev: Fix PFB font embedding. Bug #69717
+         * CairoOutputDev: Do not set an invalid matrix in drawImage(). Bug #70085 
+
+        qt4:
+         * Don't crash if getXRef()->copy() fails
+
+        qt5:
+         * Don't crash if getXRef()->copy() fails
+
+        utils:
+         * pdfseparate: Allow only one %d in the filename. Bug #69434
+        
+Release 0.24.2
+        core:
+         * Windows: Fix CreateFile fails with ERROR_SHARING_VIOLATION. Bug #69597
+
+        utils:
+         * pdfseparate: improve the path building
+         * pdftocairo: check file opening failure in beginDocument()
+        
+Release 0.24.1
+        core:
+         * SplashOutputDev: use getRGBLine images if available. Bug #66928
+         * SplashOutputDev: Don't copy bitmap if we don't need to.
+         * PSOutputDev: Fix regression in -eps -level1sep rendering. Bug #68321
+         * Fix crash in malformed file 1026.asan.0.42.pdf
+         * use copyString instead of strdup where memory is freed with gfree. Bug #67666
+
+        utils:
+         * pdfdetach: don't mention xpdfrc
+         * pdftotext: Fix -bbox with stdin as input. Bug #45163
+         * pdftohtml: Fix jpeg image export. Bug #48270
+         * pdfimages: Fix typos in man page
+
+        glib:
+         * demo: Remove GTK_DISABLE_DEPRECATED compilation flag
+
+        qt4:
+         * Fix small typo in documentation
+
+        qt5:
+         * Fix small typo in documentation
+
 Release 0.24.0
         core:
          * TextOutputDev: Do not draw ligatures more than once when selected. Bug #9001

--- a/poppler/configure.ac
+++ b/poppler/configure.ac
@@ -661,20 +661,20 @@ if test x$enable_poppler_qt5 = xyes; then
   AC_CHECK_TOOL(MOCQT5, moc)
   AC_MSG_CHECKING([for Qt5 moc])
   mocversion=`$MOCQT5 -v 2>&1`
-  mocversiongrep=`echo $mocversion | grep "Qt 5"`
+  mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
   if test x"$mocversiongrep" != x"$mocversion"; then
     AC_MSG_RESULT([no])
     # moc was not the qt5 one, try with moc-qt5
     AC_CHECK_TOOL(MOCQT52, moc-qt5)
     AC_MSG_CHECKING([for Qt5 moc-qt5])
     mocversion=`$MOCQT52 -v 2>&1`
-    mocversiongrep=`echo $mocversion | grep "Qt 5"`
+    mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
     if test x"$mocversiongrep" != x"$mocversion"; then
       AC_CHECK_TOOL(QTCHOOSER, qtchooser)
       AC_MSG_CHECKING([for qtchooser])
       qt5tooldir=`QT_SELECT=qt5 qtchooser -print-env | grep QTTOOLDIR | cut -d '=' -f 2 | cut -d \" -f 2`
       mocversion=`$qt5tooldir/moc -v 2>&1`
-      mocversiongrep=`echo $mocversion | grep "Qt 5"`
+      mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
       if test x"$mocversiongrep" != x"$mocversion"; then
         # no valid moc found
         enable_poppler_qt5=no;

--- a/poppler/configure.ac
+++ b/poppler/configure.ac
@@ -1,6 +1,6 @@
 m4_define([poppler_version_major],[0])
 m4_define([poppler_version_minor],[24])
-m4_define([poppler_version_micro],[0])
+m4_define([poppler_version_micro],[5])
 m4_define([poppler_version],[poppler_version_major.poppler_version_minor.poppler_version_micro])
 
 AC_PREREQ(2.59)
@@ -661,20 +661,20 @@ if test x$enable_poppler_qt5 = xyes; then
   AC_CHECK_TOOL(MOCQT5, moc)
   AC_MSG_CHECKING([for Qt5 moc])
   mocversion=`$MOCQT5 -v 2>&1`
-  mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
+  mocversiongrep=`echo $mocversion | grep "Qt 5"`
   if test x"$mocversiongrep" != x"$mocversion"; then
     AC_MSG_RESULT([no])
     # moc was not the qt5 one, try with moc-qt5
     AC_CHECK_TOOL(MOCQT52, moc-qt5)
     AC_MSG_CHECKING([for Qt5 moc-qt5])
     mocversion=`$MOCQT52 -v 2>&1`
-    mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
+    mocversiongrep=`echo $mocversion | grep "Qt 5"`
     if test x"$mocversiongrep" != x"$mocversion"; then
       AC_CHECK_TOOL(QTCHOOSER, qtchooser)
       AC_MSG_CHECKING([for qtchooser])
       qt5tooldir=`QT_SELECT=qt5 qtchooser -print-env | grep QTTOOLDIR | cut -d '=' -f 2 | cut -d \" -f 2`
       mocversion=`$qt5tooldir/moc -v 2>&1`
-      mocversiongrep=`echo $mocversion | grep "Qt\|moc 5"`
+      mocversiongrep=`echo $mocversion | grep "Qt 5"`
       if test x"$mocversiongrep" != x"$mocversion"; then
         # no valid moc found
         enable_poppler_qt5=no;

--- a/poppler/glib/demo/Makefile.am
+++ b/poppler/glib/demo/Makefile.am
@@ -3,7 +3,6 @@ INCLUDES = 					\
 	-I$(top_builddir)/glib			\
 	$(GTK_TEST_CFLAGS)			\
 	$(POPPLER_GLIB_DISABLE_DEPRECATED)	\
-	-DGTK_DISABLE_DEPRECATED		\
 	$(POPPLER_GLIB_DISABLE_SINGLE_INCLUDES)
 
 AM_LDFLAGS = @auto_import_flags@

--- a/poppler/goo/gfile.cc
+++ b/poppler/goo/gfile.cc
@@ -24,6 +24,7 @@
 // Copyright (C) 2013 Adam Reichold <adamreichold@myopera.com>
 // Copyright (C) 2013 Adrian Johnson <ajohnson@redneon.com>
 // Copyright (C) 2013 Peter Breitenlohner <peb@mppmu.mpg.de>
+// Copyright (C) 2013 Thomas Freitag <Thomas.Freitag@alfa.de>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -621,7 +622,7 @@ Goffset GooFile::size() const {
 GooFile* GooFile::open(const GooString *fileName) {
   HANDLE handle = CreateFile(fileName->getCString(),
                               GENERIC_READ,
-                              FILE_SHARE_READ,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE,
                               NULL,
                               OPEN_EXISTING,
                               FILE_ATTRIBUTE_NORMAL, NULL);
@@ -632,7 +633,7 @@ GooFile* GooFile::open(const GooString *fileName) {
 GooFile* GooFile::open(const wchar_t *fileName) {
   HANDLE handle = CreateFileW(fileName,
                               GENERIC_READ,
-                              FILE_SHARE_READ,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE,
                               NULL,
                               OPEN_EXISTING,
                               FILE_ATTRIBUTE_NORMAL, NULL);

--- a/poppler/poppler/Annot.cc
+++ b/poppler/poppler/Annot.cc
@@ -4990,7 +4990,7 @@ void AnnotWidget::generateFieldAppearance() {
   }
 
   // build the appearance stream
-  appearStream = new MemStream(strdup(appearBuf->getCString()), 0,
+  appearStream = new MemStream(copyString(appearBuf->getCString()), 0,
       appearBuf->getLength(), &appearDict);
   appearance.free();
   appearance.initStream(appearStream);

--- a/poppler/poppler/CairoOutputDev.cc
+++ b/poppler/poppler/CairoOutputDev.cc
@@ -2938,7 +2938,8 @@ void CairoOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
   if (maskPattern) {
     if (!printing)
       cairo_clip (cairo);
-    cairo_set_matrix (cairo, &mask_matrix);
+    if (mask)
+      cairo_set_matrix (cairo, &mask_matrix);
     cairo_mask (cairo, maskPattern);
   } else {
     if (printing)

--- a/poppler/poppler/Catalog.cc
+++ b/poppler/poppler/Catalog.cc
@@ -27,6 +27,7 @@
 // Copyright (C) 2012 Fabio D'Urso <fabiodurso@hotmail.it>
 // Copyright (C) 2013 Thomas Freitag <Thomas.Freitag@alfa.de>
 // Copyright (C) 2013 Julien Nabet <serval2412@yahoo.fr>
+// Copyright (C) 2013 José Aliste <jaliste@src.gnome.org>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -657,9 +658,20 @@ void NameTree::addEntry(Entry *entry)
   ++length;
 }
 
+int NameTree::Entry::cmpEntry(const void *voidEntry, const void *voidOtherEntry)
+{
+  Entry *entry = *(NameTree::Entry **) voidEntry;
+  Entry *otherEntry = *(NameTree::Entry **) voidOtherEntry;
+
+  return entry->name.cmp(&otherEntry->name);
+}
+
 void NameTree::init(XRef *xrefA, Object *tree) {
   xref = xrefA;
   parse(tree);
+  if (entries && length > 0) {
+    qsort(entries, length, sizeof(Entry *), Entry::cmpEntry);
+  }
 }
 
 void NameTree::parse(Object *tree) {

--- a/poppler/poppler/Catalog.h
+++ b/poppler/poppler/Catalog.h
@@ -22,6 +22,7 @@
 // Copyright (C) 2010 Hib Eris <hib@hiberis.nl>
 // Copyright (C) 2012 Fabio D'Urso <fabiodurso@hotmail.it>
 // Copyright (C) 2013 Thomas Freitag <Thomas.Freitag@alfa.de>
+// Copyright (C) 2013 José Aliste <jaliste@src.gnome.org>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -76,6 +77,7 @@ private:
     GooString name;
     Object value;
     void free();
+    static int cmpEntry(const void *voidEntry, const void *voidOtherEntry);
     static int cmp(const void *key, const void *entry);
   };
 

--- a/poppler/poppler/Dict.cc
+++ b/poppler/poppler/Dict.cc
@@ -96,7 +96,7 @@ Dict::Dict(Dict* dictA) {
   sorted = dictA->sorted;
   entries = (DictEntry *)gmallocn(size, sizeof(DictEntry));
   for (int i=0; i<length; i++) {
-    entries[i].key = strdup(dictA->entries[i].key);
+    entries[i].key = copyString(dictA->entries[i].key);
     dictA->entries[i].val.copy(&entries[i].val);
   }
 }

--- a/poppler/poppler/GfxState.cc
+++ b/poppler/poppler/GfxState.cc
@@ -25,6 +25,7 @@
 // Copyright (C) 2011 Andrea Canciani <ranma42@gmail.com>
 // Copyright (C) 2012 William Bader <williambader@hotmail.com>
 // Copyright (C) 2013 Lu Wang <coolwanglu@gmail.com>
+// Copyright (C) 2013 Fabio D'Urso <fabiodurso@hotmail.it>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -2361,7 +2362,7 @@ void GfxSeparationColorSpace::createMapping(GooList *separationList, int maxSepC
         if (!sepCS->getName()->cmp(name)) {
           if (sepCS->getFunc()->hasDifferentResultSet(func)) {
             error(errSyntaxWarning, -1,
-              "Different functions found for '{0:s}', convert immediately", name);
+              "Different functions found for '{0:t}', convert immediately", name);
             gfree(mapping);
             mapping = NULL;
             return;
@@ -2374,7 +2375,7 @@ void GfxSeparationColorSpace::createMapping(GooList *separationList, int maxSepC
       }
       if (separationList->getLength() == maxSepComps) {
         error(errSyntaxWarning, -1,
-	        "Too many ({0:d}) spots, convert '{1:s}' immediately", maxSepComps, name);
+	        "Too many ({0:d}) spots, convert '{1:t}' immediately", maxSepComps, name);
         gfree(mapping);
         mapping = NULL;
         return;
@@ -2675,7 +2676,7 @@ void GfxDeviceNColorSpace::createMapping(GooList *separationList, int maxSepComp
         if (!sepCS->getName()->cmp(names[i])) {
           if (sepFunc != NULL && sepCS->getFunc()->hasDifferentResultSet(sepFunc)) {
             error(errSyntaxWarning, -1,
-              "Different functions found for '{0:s}', convert immediately", names[i]);
+              "Different functions found for '{0:t}', convert immediately", names[i]);
             gfree(mapping);
             mapping = NULL;
             overprintMask = 0xffffffff;
@@ -2691,7 +2692,7 @@ void GfxDeviceNColorSpace::createMapping(GooList *separationList, int maxSepComp
       if (!found) {
         if (separationList->getLength() == maxSepComps) {
           error(errSyntaxWarning, -1,
-            "Too many ({0:d}) spots, convert '{1:s}' immediately", maxSepComps, names[i]);
+            "Too many ({0:d}) spots, convert '{1:t}' immediately", maxSepComps, names[i]);
           gfree(mapping);
           mapping = NULL;
           overprintMask = 0xffffffff;

--- a/poppler/poppler/JBIG2Stream.cc
+++ b/poppler/poppler/JBIG2Stream.cc
@@ -21,6 +21,7 @@
 // Copyright (C) 2012 William Bader <williambader@hotmail.com>
 // Copyright (C) 2012 Thomas Freitag <Thomas.Freitag@alfa.de>
 // Copyright (C) 2013 Adrian Johnson <ajohnson@redneon.com>
+// Copyright (C) 2013 Fabio D'Urso <fabiodurso@hotmail.it>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -1495,7 +1496,7 @@ void JBIG2Stream::readSegments() {
 	// arithmetic-coded symbol dictionary segments when numNewSyms
 	// == 0.  Segments like this often occur for blank pages.
 	
-	error(errSyntaxError, curStr->getPos(), "{0:d} extraneous byte{1:s} after segment",
+	error(errSyntaxError, curStr->getPos(), "{0:lld} extraneous byte{1:s} after segment",
 	      segExtraBytes, (segExtraBytes > 1) ? "s" : "");
 	
 	// Burn through the remaining bytes -- inefficient, but

--- a/poppler/poppler/Lexer.cc
+++ b/poppler/poppler/Lexer.cc
@@ -13,7 +13,7 @@
 // All changes made under the Poppler project to this file are licensed
 // under GPL version 2 or later
 //
-// Copyright (C) 2006-2010, 2012 Albert Astals Cid <aacid@kde.org>
+// Copyright (C) 2006-2010, 2012, 2013 Albert Astals Cid <aacid@kde.org>
 // Copyright (C) 2006 Krzysztof Kowalczyk <kkowalczyk@gmail.com>
 // Copyright (C) 2010 Carlos Garcia Campos <carlosgc@gnome.org>
 // Copyright (C) 2012, 2013 Adrian Johnson <ajohnson@redneon.com>
@@ -581,7 +581,7 @@ Object *Lexer::getObj(Object *obj, int objNum) {
   return obj;
 }
 
-Object *Lexer::getObj(Object *obj, const char *cmdA) {
+Object *Lexer::getObj(Object *obj, const char *cmdA, int objNum) {
   char *p;
   int c;
   GBool comment;
@@ -591,7 +591,7 @@ Object *Lexer::getObj(Object *obj, const char *cmdA) {
   comment = gFalse;
   const char *cmd1 = tokBuf;
   *tokBuf = 0;
-  while (strcmp(cmdA, cmd1)) {
+  while (strcmp(cmdA, cmd1) && (objNum < 0 || xref->getNumEntry(getPos()) == objNum)) {
     while (1) {
       if ((c = getChar()) == EOF) {
         return obj->initEOF();

--- a/poppler/poppler/Lexer.h
+++ b/poppler/poppler/Lexer.h
@@ -13,7 +13,7 @@
 // All changes made under the Poppler project to this file are licensed
 // under GPL version 2 or later
 //
-// Copyright (C) 2006, 2007, 2010 Albert Astals Cid <aacid@kde.org>
+// Copyright (C) 2006, 2007, 2010, 2013 Albert Astals Cid <aacid@kde.org>
 // Copyright (C) 2006 Krzysztof Kowalczyk <kkowalczyk@gmail.com>
 // Copyright (C) 2013 Adrian Johnson <ajohnson@redneon.com>
 // Copyright (C) 2013 Thomas Freitag <Thomas.Freitag@alfa.de>
@@ -57,7 +57,7 @@ public:
 
   // Get the next object from the input stream.
   Object *getObj(Object *obj, int objNum = -1);
-  Object *getObj(Object *obj, const char *cmdA);
+  Object *getObj(Object *obj, const char *cmdA, int objNum);
 
   // Skip to the beginning of the next line in the input stream.
   void skipToNextLine();

--- a/poppler/poppler/Makefile.am
+++ b/poppler/poppler/Makefile.am
@@ -157,7 +157,7 @@ libpoppler_la_LIBADD =				\
 	$(PTHREAD_LIBS)				\
 	$(win32_libs)
 
-libpoppler_la_LDFLAGS = -version-info 43:0:0 @create_shared_lib@ @auto_import_flags@
+libpoppler_la_LDFLAGS = -version-info 44:0:0 @create_shared_lib@ @auto_import_flags@
 
 if ENABLE_XPDF_HEADERS
 

--- a/poppler/poppler/Parser.cc
+++ b/poppler/poppler/Parser.cc
@@ -13,7 +13,7 @@
 // All changes made under the Poppler project to this file are licensed
 // under GPL version 2 or later
 //
-// Copyright (C) 2006, 2009, 201, 2010 Albert Astals Cid <aacid@kde.org>
+// Copyright (C) 2006, 2009, 201, 2010, 2013 Albert Astals Cid <aacid@kde.org>
 // Copyright (C) 2006 Krzysztof Kowalczyk <kkowalczyk@gmail.com>
 // Copyright (C) 2009 Ilya Gorenbein <igorenbein@finjan.com>
 // Copyright (C) 2012 Hib Eris <hib@hiberis.nl>
@@ -242,7 +242,7 @@ Stream *Parser::makeStream(Object *dict, Guchar *fileKey,
 
   // refill token buffers and check for 'endstream'
   shift();  // kill '>>'
-  shift("endstream");  // kill 'stream'
+  shift("endstream", objNum);  // kill 'stream'
   if (buf1.isCmd("endstream")) {
     shift();
   } else {
@@ -250,9 +250,6 @@ Stream *Parser::makeStream(Object *dict, Guchar *fileKey,
     if (strict) return NULL;
     if (xref) {
       // shift until we find the proper endstream or we change to another object or reach eof
-      while (!buf1.isCmd("endstream") && xref->getNumEntry(lexer->getPos()) == objNum && !buf1.isEOF()) {
-        shift("endstream");
-      }
       length = lexer->getPos() - pos;
       if (buf1.isCmd("endstream")) {
         obj.initInt64(length);
@@ -303,7 +300,7 @@ void Parser::shift(int objNum) {
     lexer->getObj(&buf2, objNum);
 }
 
-void Parser::shift(const char *cmdA) {
+void Parser::shift(const char *cmdA, int objNum) {
   if (inlineImg > 0) {
     if (inlineImg < 2) {
       ++inlineImg;
@@ -321,8 +318,8 @@ void Parser::shift(const char *cmdA) {
   if (inlineImg > 0) {
     buf2.initNull();
   } else if (buf1.isCmd(cmdA)) {
-    lexer->getObj(&buf2, -1);
+    lexer->getObj(&buf2, objNum);
   } else {
-    lexer->getObj(&buf2, cmdA);
+    lexer->getObj(&buf2, cmdA, objNum);
   }
 }

--- a/poppler/poppler/Parser.h
+++ b/poppler/poppler/Parser.h
@@ -13,7 +13,7 @@
 // All changes made under the Poppler project to this file are licensed
 // under GPL version 2 or later
 //
-// Copyright (C) 2006, 2010 Albert Astals Cid <aacid@kde.org>
+// Copyright (C) 2006, 2010, 2013 Albert Astals Cid <aacid@kde.org>
 // Copyright (C) 2012 Hib Eris <hib@hiberis.nl>
 // Copyright (C) 2013 Adrian Johnson <ajohnson@redneon.com>
 // Copyright (C) 2013 Thomas Freitag <Thomas.Freitag@alfa.de>
@@ -75,7 +75,7 @@ private:
 		     int objNum, int objGen, int recursion,
 		     GBool strict);
   void shift(int objNum = -1);
-  void shift(const char *cmdA);
+  void shift(const char *cmdA, int objNum);
 };
 
 #endif

--- a/poppler/poppler/SplashOutputDev.cc
+++ b/poppler/poppler/SplashOutputDev.cc
@@ -2862,20 +2862,28 @@ GBool SplashOutputDev::imageSrc(void *data, SplashColorPtr colorLine,
       break;
     case splashModeRGB8:
     case splashModeBGR8:
-      for (x = 0, q = colorLine; x < imgData->width; ++x, p += nComps) {
-	imgData->colorMap->getRGB(p, &rgb);
-	*q++ = colToByte(rgb.r);
-	*q++ = colToByte(rgb.g);
-	*q++ = colToByte(rgb.b);
+      if (imgData->colorMap->useRGBLine()) {
+	imgData->colorMap->getRGBLine(p, (Guchar *) colorLine, imgData->width);
+      } else {
+	for (x = 0, q = colorLine; x < imgData->width; ++x, p += nComps) {
+	  imgData->colorMap->getRGB(p, &rgb);
+	  *q++ = colToByte(rgb.r);
+	  *q++ = colToByte(rgb.g);
+	  *q++ = colToByte(rgb.b);
+	}
       }
       break;
     case splashModeXBGR8:
-      for (x = 0, q = colorLine; x < imgData->width; ++x, p += nComps) {
-	imgData->colorMap->getRGB(p, &rgb);
-	*q++ = colToByte(rgb.r);
-	*q++ = colToByte(rgb.g);
-	*q++ = colToByte(rgb.b);
-	*q++ = 255;
+      if (imgData->colorMap->useRGBLine()) {
+	imgData->colorMap->getRGBXLine(p, (Guchar *) colorLine, imgData->width);
+      } else {
+	for (x = 0, q = colorLine; x < imgData->width; ++x, p += nComps) {
+	  imgData->colorMap->getRGB(p, &rgb);
+	  *q++ = colToByte(rgb.r);
+	  *q++ = colToByte(rgb.g);
+	  *q++ = colToByte(rgb.b);
+	  *q++ = 255;
+	}
       }
       break;
 #if SPLASH_CMYK
@@ -3794,7 +3802,7 @@ void SplashOutputDev::beginTransparencyGroup(GfxState *state, double *bbox,
   transpGroup->ty = ty;
   transpGroup->blendingColorSpace = blendingColorSpace;
   transpGroup->isolated = isolated;
-  transpGroup->shape = (knockout) ? SplashBitmap::copy(bitmap) : NULL;
+  transpGroup->shape = (knockout && !isolated) ? SplashBitmap::copy(bitmap) : NULL;
   transpGroup->knockout = gFalse; 
   transpGroup->knockoutOpacity = 1.0;
   transpGroup->next = transpGroupStack;

--- a/poppler/poppler/Stream.cc
+++ b/poppler/poppler/Stream.cc
@@ -819,6 +819,9 @@ GBool FileStream::fillBuf() {
     n = fileStreamBufSize;
   }
   n = file->read(buf, n, offset);
+  if (n == -1) {
+    return gFalse;
+  }
   offset += n;
   bufEnd = buf + n;
   if (bufPtr >= bufEnd) {

--- a/poppler/qt4/src/poppler-annotation.cc
+++ b/poppler/qt4/src/poppler-annotation.cc
@@ -1,5 +1,5 @@
 /* poppler-annotation.cc: qt interface to poppler
- * Copyright (C) 2006, 2009, 2012 Albert Astals Cid <aacid@kde.org>
+ * Copyright (C) 2006, 2009, 2012, 2013 Albert Astals Cid <aacid@kde.org>
  * Copyright (C) 2006, 2008, 2010 Pino Toscano <pino@kde.org>
  * Copyright (C) 2012, Guillermo A. Amaral B. <gamaral@kde.org>
  * Copyright (C) 2012, 2013 Fabio D'Urso <fabiodurso@hotmail.it>
@@ -3657,7 +3657,8 @@ void LinkAnnotation::store( QDomNode & node, QDomDocument & document ) const
                 Poppler::LinkGoto * go = static_cast< Poppler::LinkGoto * >( linkDestination() );
                 hyperlinkElement.setAttribute( "type", "GoTo" );
                 hyperlinkElement.setAttribute( "filename", go->fileName() );
-                hyperlinkElement.setAttribute( "destionation", go->destination().toString() );
+                hyperlinkElement.setAttribute( "destionation", go->destination().toString() ); // TODO Remove for poppler 0.28
+                hyperlinkElement.setAttribute( "destination", go->destination().toString() );
                 break;
             }
             case Poppler::Link::Execute:

--- a/poppler/qt4/src/poppler-document.cc
+++ b/poppler/qt4/src/poppler-document.cc
@@ -1,7 +1,7 @@
 /* poppler-document.cc: qt interface to poppler
  * Copyright (C) 2005, Net Integration Technologies, Inc.
  * Copyright (C) 2005, 2008, Brad Hards <bradh@frogmouth.net>
- * Copyright (C) 2005-2010, 2012, Albert Astals Cid <aacid@kde.org>
+ * Copyright (C) 2005-2010, 2012, 2013, Albert Astals Cid <aacid@kde.org>
  * Copyright (C) 2006-2010, Pino Toscano <pino@kde.org>
  * Copyright (C) 2010, 2011 Hib Eris <hib@hiberis.nl>
  * Copyright (C) 2012 Koji Otani <sho@bbr.jp>
@@ -269,6 +269,8 @@ namespace Poppler {
 	    return QString();
 
 	QScopedPointer<XRef> xref(m_doc->doc->getXRef()->copy());
+	if (!xref)
+		return QString();
 	xref->getDocInfo(&info);
 	if ( !info.isDict() )
 	    return QString();
@@ -300,6 +302,8 @@ namespace Poppler {
 	    return QStringList();
 
 	QScopedPointer<XRef> xref(m_doc->doc->getXRef()->copy());
+	if (!xref)
+		return QStringList();
 	xref->getDocInfo(&info);
 	if ( !info.isDict() )
 	    return QStringList();
@@ -323,6 +327,8 @@ namespace Poppler {
 
 	Object info;
 	QScopedPointer<XRef> xref(m_doc->doc->getXRef()->copy());
+	if (!xref)
+		return QDateTime();
 	xref->getDocInfo(&info);
 	if ( !info.isDict() ) {
 	    info.free();

--- a/poppler/qt4/src/poppler-qt4.h
+++ b/poppler/qt4/src/poppler-qt4.h
@@ -103,7 +103,7 @@ namespace Poppler {
     public:
       /**
 	 The default constructor sets the \p text and the rectangle that
-	 contains the text. Coordinated for the \p bBox are in points =
+	 contains the text. Coordinates for the \p bBox are in points =
 	 1/72 of an inch.
       */
       TextBox(const QString& text, const QRectF &bBox);

--- a/poppler/qt5/src/poppler-annotation.cc
+++ b/poppler/qt5/src/poppler-annotation.cc
@@ -3644,7 +3644,8 @@ void LinkAnnotation::store( QDomNode & node, QDomDocument & document ) const
                 Poppler::LinkGoto * go = static_cast< Poppler::LinkGoto * >( linkDestination() );
                 hyperlinkElement.setAttribute( "type", "GoTo" );
                 hyperlinkElement.setAttribute( "filename", go->fileName() );
-                hyperlinkElement.setAttribute( "destionation", go->destination().toString() );
+                hyperlinkElement.setAttribute( "destionation", go->destination().toString() ); // TODO remove for poppler 0.28
+                hyperlinkElement.setAttribute( "destination", go->destination().toString() );
                 break;
             }
             case Poppler::Link::Execute:

--- a/poppler/qt5/src/poppler-document.cc
+++ b/poppler/qt5/src/poppler-document.cc
@@ -255,6 +255,8 @@ namespace Poppler {
 	    return QString();
 
 	QScopedPointer<XRef> xref(m_doc->doc->getXRef()->copy());
+	if (!xref)
+		return QString();
 	xref->getDocInfo(&info);
 	if ( !info.isDict() )
 	    return QString();
@@ -286,6 +288,8 @@ namespace Poppler {
 	    return QStringList();
 
 	QScopedPointer<XRef> xref(m_doc->doc->getXRef()->copy());
+	if (!xref)
+		return QStringList();
 	xref->getDocInfo(&info);
 	if ( !info.isDict() )
 	    return QStringList();
@@ -309,6 +313,8 @@ namespace Poppler {
 
 	Object info;
 	QScopedPointer<XRef> xref(m_doc->doc->getXRef()->copy());
+	if (!xref)
+		return QDateTime();
 	xref->getDocInfo(&info);
 	if ( !info.isDict() ) {
 	    info.free();

--- a/poppler/qt5/src/poppler-qt5.h
+++ b/poppler/qt5/src/poppler-qt5.h
@@ -104,7 +104,7 @@ namespace Poppler {
     public:
       /**
 	 The default constructor sets the \p text and the rectangle that
-	 contains the text. Coordinated for the \p bBox are in points =
+	 contains the text. Coordinates for the \p bBox are in points =
 	 1/72 of an inch.
       */
       TextBox(const QString& text, const QRectF &bBox);

--- a/poppler/utils/HtmlOutputDev.cc
+++ b/poppler/utils/HtmlOutputDev.cc
@@ -36,6 +36,7 @@
 // Copyright (C) 2012 Pino Toscano <pino@kde.org>
 // Copyright (C) 2013 Thomas Freitag <Thomas.Freitag@alfa.de>
 // Copyright (C) 2013 Julien Nabet <serval2412@yahoo.fr>
+// Copyright (C) 2013 Johannes Brandstätter <jbrandstaetter@gmail.com>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -1502,7 +1503,8 @@ void HtmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
   /*if( !globalParams->getErrQuiet() )
     printf("image stream of kind %d\n", str->getKind());*/
   // dump JPEG file
-  if (dumpJPEG && str->getKind() == strDCT) {
+  if (dumpJPEG && str->getKind() == strDCT && (colorMap->getNumPixelComps() == 1 ||
+	  colorMap->getNumPixelComps() == 3) && !inlineImg) {
     drawJpegImage(state, str);
   }
   else {

--- a/poppler/utils/pdfdetach.1
+++ b/poppler/utils/pdfdetach.1
@@ -11,14 +11,6 @@ extractor (version 3.03)
 .B Pdfdetach
 lists or extracts embedded files (attachments) from a Portable
 Document Format (PDF) file.
-.SH CONFIGURATION FILE
-Pdfdetach reads a configuration file at startup.  It first tries to
-find the user's private config file, ~/.xpdfrc.  If that doesn't
-exist, it looks for a system-wide config file, typically
-/usr/local/etc/xpdfrc (but this location can be changed when pdfinfo
-is built).  See the
-.BR xpdfrc (5)
-man page for details.
 .SH OPTIONS
 Some of the following options can be set with configuration file
 commands.  These are listed in square brackets with the description of
@@ -44,12 +36,8 @@ Set the file name used when saving an embedded file with the "\-save"
 switch, or the directory used by "\-saveall".
 .TP
 .BI \-enc " encoding-name"
-Sets the encoding to use for text output (embedded file names).  The
-.I encoding\-name
-must be defined with the unicodeMap command (see
-.BR xpdfrc (5)).
-This defaults to "Latin1" (which is a built-in encoding).
-.RB "[config file: " textEncoding ]
+Sets the encoding to use for text output (embedded file names).
+This defaults to "UTF-8".
 .TP
 .BI \-opw " password"
 Specify the owner password for the PDF file.  Providing this will
@@ -57,11 +45,6 @@ bypass all security restrictions.
 .TP
 .BI \-upw " password"
 Specify the user password for the PDF file.
-.TP
-.BI \-cfg " config-file"
-Read
-.I config-file
-in place of ~/.xpdfrc or the system-wide config file.
 .TP
 .B \-v
 Print copyright and version information.

--- a/poppler/utils/pdfdetach.cc
+++ b/poppler/utils/pdfdetach.cc
@@ -14,6 +14,7 @@
 // under GPL version 2 or later
 //
 // Copyright (C) 2011 Carlos Garcia Campos <carlosgc@gnome.org>
+// Copyright (C) 2013 Yury G. Kudryashov <urkud.urkud@gmail.com>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -46,7 +47,6 @@ static char savePath[1024] = "";
 static char textEncName[128] = "";
 static char ownerPassword[33] = "\001";
 static char userPassword[33] = "\001";
-static char cfgFileName[256] = "";
 static GBool printVersion = gFalse;
 static GBool printHelp = gFalse;
 
@@ -65,8 +65,6 @@ static ArgDesc argDesc[] = {
    "owner password (for encrypted files)"},
   {"-upw",    argString,   userPassword,   sizeof(userPassword),
    "user password (for encrypted files)"},
-  {"-cfg",        argString,      cfgFileName,    sizeof(cfgFileName),
-   "configuration file to use in place of .xpdfrc"},
   {"-v",      argFlag,     &printVersion,  0,
    "print copyright and version info"},
   {"-h",      argFlag,     &printHelp,     0,
@@ -121,7 +119,7 @@ int main(int argc, char *argv[]) {
   fileName = new GooString(argv[1]);
 
   // read config file
-  globalParams = new GlobalParams(cfgFileName);
+  globalParams = new GlobalParams();
   if (textEncName[0]) {
     globalParams->setTextEncoding(textEncName);
   }

--- a/poppler/utils/pdffonts.cc
+++ b/poppler/utils/pdffonts.cc
@@ -17,6 +17,7 @@
 // Copyright (C) 2007-2008, 2010 Albert Astals Cid <aacid@kde.org>
 // Copyright (C) 2010 Hib Eris <hib@hiberis.nl>
 // Copyright (C) 2012 Adrian Johnson <ajohnson@redneon.com>
+// Copyright (C) 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -149,6 +150,12 @@ int main(int argc, char *argv[]) {
   }
   if (lastPage < 1 || lastPage > doc->getNumPages()) {
     lastPage = doc->getNumPages();
+  }
+  if (lastPage < firstPage) {
+    fprintf(stderr,
+            "Wrong page range given: the first page (%d) can not be after the last page (%d).\n",
+            firstPage, lastPage);
+    goto err1;
   }
 
   // get the fonts

--- a/poppler/utils/pdfimages.1
+++ b/poppler/utils/pdfimages.1
@@ -40,7 +40,7 @@ Instead of writing the images, list the images along with various information fo
 .IR image-root
 with this option.
 .IP
-The following information is listed for each font:
+The following information is listed for each image:
 .RS
 .TP
 .B page
@@ -133,7 +133,7 @@ ccitt - CCITT Group 3 or Group 4 Fax
 "yes" if the interpolation is to be performed when scaling up the image
 .TP
 .B object ID
-the font dictionary object ID (number and generation)
+the image dictionary object ID (number and generation)
 .RE
 .TP
 .BI \-opw " password"

--- a/poppler/utils/pdfimages.cc
+++ b/poppler/utils/pdfimages.cc
@@ -19,6 +19,7 @@
 // Copyright (C) 2010 Hib Eris <hib@hiberis.nl>
 // Copyright (C) 2010 Jakob Voss <jakob.voss@gbv.de>
 // Copyright (C) 2012 Adrian Johnson <ajohnson@redneon.com>
+// Copyright (C) 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -166,6 +167,12 @@ int main(int argc, char *argv[]) {
     firstPage = 1;
   if (lastPage < 1 || lastPage > doc->getNumPages())
     lastPage = doc->getNumPages();
+  if (lastPage < firstPage) {
+    error(errCommandLine, -1,
+          "Wrong page range given: the first page ({0:d}) can not be after the last page ({1:d}).",
+          firstPage, lastPage);
+    goto err1;
+  }
 
   // write image files
   imgOut = new ImageOutputDev(imgRoot, pageNames, dumpJPEG, listImages);

--- a/poppler/utils/pdfinfo.cc
+++ b/poppler/utils/pdfinfo.cc
@@ -19,6 +19,7 @@
 // Copyright (C) 2011 Vittal Aithal <vittal.aithal@cognidox.com>
 // Copyright (C) 2012, 2013 Adrian Johnson <ajohnson@redneon.com>
 // Copyright (C) 2012 Fabio D'Urso <fabiodurso@hotmail.it>
+// Copyright (C) 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -201,6 +202,12 @@ int main(int argc, char *argv[]) {
   }
   if (lastPage < 1 || lastPage > doc->getNumPages()) {
     lastPage = doc->getNumPages();
+  }
+  if (lastPage < firstPage) {
+    error(errCommandLine, -1,
+          "Wrong page range given: the first page ({0:d}) can not be after the last page ({1:d}).",
+          firstPage, lastPage);
+    goto err2;
   }
 
   // print doc info

--- a/poppler/utils/pdftocairo.cc
+++ b/poppler/utils/pdftocairo.cc
@@ -26,6 +26,8 @@
 // Copyright (C) 2011 Thomas Freitag <Thomas.Freitag@alfa.de>
 // Copyright (C) 2011 Carlos Garcia Campos <carlosgc@gnome.org>
 // Copyright (C) 2012 Koji Otani <sho@bbr.jp>
+// Copyright (C) 2013 Lu Wang <coolwanglu@gmail.com>
+// Copyright (C) 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -484,7 +486,13 @@ static void beginDocument(GooString *outputFileName, double w, double h)
     if (outputFileName->cmp("fd://0") == 0)
       output_file = stdout;
     else
+    {
       output_file = fopen(outputFileName->getCString(), "wb");
+      if (!output_file) {
+        fprintf(stderr, "Error opening output file %s\n", outputFileName->getCString());
+        exit(2);
+      }
+    }
 
     if (ps || eps) {
 #if CAIRO_HAS_PS_SURFACE
@@ -957,6 +965,12 @@ int main(int argc, char *argv[]) {
   if (lastPage < 1 || lastPage > doc->getNumPages())
     lastPage = doc->getNumPages();
 
+  if (lastPage < firstPage) {
+    fprintf(stderr,
+            "Wrong page range given: the first page (%d) can not be after the last page (%d).\n",
+            firstPage, lastPage);
+    exit(99);
+  }
   if (eps && firstPage != lastPage) {
     fprintf(stderr, "EPS files can only contain one page.\n");
     exit(99);

--- a/poppler/utils/pdftohtml.cc
+++ b/poppler/utils/pdftohtml.cc
@@ -16,7 +16,7 @@
 // Copyright (C) 2007-2008, 2010, 2012 Albert Astals Cid <aacid@kde.org>
 // Copyright (C) 2010 Hib Eris <hib@hiberis.nl>
 // Copyright (C) 2010 Mike Slegeir <tehpola@yahoo.com>
-// Copyright (C) 2010 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
+// Copyright (C) 2010, 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 // Copyright (C) 2010 OSSD CDAC Mumbai by Leena Chourey (leenac@cdacmumbai.in) and Onkar Potdar (onkar@cdacmumbai.in)
 // Copyright (C) 2011 Steven Murdoch <Steven.Murdoch@cl.cam.ac.uk>
 // Copyright (C) 2012 Igor Slepchin <igor.redhat@gmail.com>
@@ -322,6 +322,12 @@ int main(int argc, char *argv[]) {
     firstPage = 1;
   if (lastPage < 1 || lastPage > doc->getNumPages())
     lastPage = doc->getNumPages();
+  if (lastPage < firstPage) {
+    error(errCommandLine, -1,
+          "Wrong page range given: the first page ({0:d}) can not be after the last page ({1:d}).",
+          firstPage, lastPage);
+    goto error;
+  }
 
   doc->getDocInfo(&info);
   if (info.isDict()) {

--- a/poppler/utils/pdftoppm.cc
+++ b/poppler/utils/pdftoppm.cc
@@ -25,6 +25,7 @@
 // Copyright (C) 2010 William Bader <williambader@hotmail.com>
 // Copyright (C) 2011-2013 Thomas Freitag <Thomas.Freitag@alfa.de>
 // Copyright (C) 2013 Adam Reichold <adamreichold@myopera.com>
+// Copyright (C) 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -412,6 +413,12 @@ int main(int argc, char *argv[]) {
     lastPage = firstPage;
   if (lastPage < 1 || lastPage > doc->getNumPages())
     lastPage = doc->getNumPages();
+  if (lastPage < firstPage) {
+    fprintf(stderr,
+            "Wrong page range given: the first page (%d) can not be after the last page (%d).\n",
+            firstPage, lastPage);
+    goto err1;
+  }
 
   if (singleFile && firstPage < lastPage) {
     if (!quiet) {

--- a/poppler/utils/pdftops.cc
+++ b/poppler/utils/pdftops.cc
@@ -22,6 +22,7 @@
 // Copyright (C) 2009, 2011, 2012 William Bader <williambader@hotmail.com>
 // Copyright (C) 2010 Hib Eris <hib@hiberis.nl>
 // Copyright (C) 2012 Thomas Freitag <Thomas.Freitag@alfa.de>
+// Copyright (C) 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -379,6 +380,12 @@ int main(int argc, char *argv[]) {
   }
   if (lastPage < 1 || lastPage > doc->getNumPages()) {
     lastPage = doc->getNumPages();
+  }
+  if (lastPage < firstPage) {
+    error(errCommandLine, -1,
+          "Wrong page range given: the first page ({0:d}) can not be after the last page ({1:d}).",
+          firstPage, lastPage);
+    goto err2;
   }
 
   // check for multi-page EPS or form

--- a/poppler/utils/pdftotext.cc
+++ b/poppler/utils/pdftotext.cc
@@ -18,10 +18,12 @@
 // Copyright (C) 2006 Dominic Lachowicz <cinamod@hotmail.com>
 // Copyright (C) 2007-2008, 2010, 2011 Albert Astals Cid <aacid@kde.org>
 // Copyright (C) 2009 Jan Jockusch <jan@jockusch.de>
-// Copyright (C) 2010 Hib Eris <hib@hiberis.nl>
+// Copyright (C) 2010, 2013 Hib Eris <hib@hiberis.nl>
 // Copyright (C) 2010 Kenneth Berland <ken@hero.com>
 // Copyright (C) 2011 Tom Gleason <tom@buildadam.com>
 // Copyright (C) 2011 Steven Murdoch <Steven.Murdoch@cl.cam.ac.uk>
+// Copyright (C) 2013 Yury G. Kudryashov <urkud.urkud@gmail.com>
+// Copyright (C) 2013 Suzuki Toshiya <mpsuzuki@hiroshima-u.ac.jp>
 //
 // To see a description of the changes please see the Changelog file that
 // came with your tarball or type make ChangeLog if you are building from git
@@ -289,6 +291,12 @@ int main(int argc, char *argv[]) {
   if (lastPage < 1 || lastPage > doc->getNumPages()) {
     lastPage = doc->getNumPages();
   }
+  if (lastPage < firstPage) {
+    error(errCommandLine, -1,
+          "Wrong page range given: the first page ({0:d}) can not be after the last page ({1:d}).",
+          firstPage, lastPage);
+    goto err3;
+  }
 
   // write HTML header
   if (htmlMeta) {
@@ -331,21 +339,17 @@ int main(int argc, char *argv[]) {
     info.free();
     fputs("</head>\n", f);
     fputs("<body>\n", f);
-    if (!bbox) fputs("<pre>\n", f);
-    if (f != stdout) {
-      fclose(f);
+    if (!bbox) {
+      fputs("<pre>\n", f);
+      if (f != stdout) {
+	fclose(f);
+      }
     }
   }
 
   // write text file
-  if (bbox) {
+  if (htmlMeta && bbox) { // htmlMeta && is superfluous but makes gcc happier
     textOut = new TextOutputDev(NULL, physLayout, fixedPitch, rawOrder, htmlMeta);
-    if (!(f = fopen(textFileName->getCString(), "ab"))) {
-      error(errIO, -1, "Couldn't open text file '{0:t}' for append", textFileName);
-      exitCode = 2;
-      delete textOut;
-      goto err3;
-    }
 
     if (textOut->isOk()) {
       fprintf(f, "<doc>\n");
@@ -370,7 +374,9 @@ int main(int argc, char *argv[]) {
       }
       fprintf(f, "</doc>\n");
     }
-    fclose(f);
+    if (f != stdout) {
+      fclose(f);
+    }
   } else {
     textOut = new TextOutputDev(textFileName->getCString(),
 				physLayout, fixedPitch, rawOrder, htmlMeta);
@@ -440,7 +446,7 @@ static void printInfoString(FILE *f, Dict *infoDict, const char *key,
   GooString *s1;
   GBool isUnicode;
   Unicode u;
-  char buf[8];
+  char buf[9];
   int i, n;
 
   if (infoDict->lookup(key, &obj)->isString()) {
@@ -464,7 +470,9 @@ static void printInfoString(FILE *f, Dict *infoDict, const char *key,
 	++i;
       }
       n = uMap->mapUnicode(u, buf, sizeof(buf));
-      fwrite(buf, 1, n, f);
+      buf[n] = '\0';
+      const std::string myString = myXmlTokenReplace(buf);
+      fputs(myString.c_str(), f);
     }
     fputs(text2, f);
   }

--- a/rpm/poppler.spec
+++ b/rpm/poppler.spec
@@ -1,11 +1,11 @@
 # spec file for package poppler
 
-%define poppler_soname 43
+%define poppler_soname 44
 %define poppler_glib_soname 8
 %define poppler_qt5_soname 1
 
 Name:           poppler
-Version:        0.24.0
+Version:        0.24.5
 Release:        1
 License:        GPLv2
 Summary:        PDF rendering library


### PR DESCRIPTION
This is an upgrade to upstream release 0.24.5. It brings various bugfixes.

It contains also a bump in soversion from .43.0.0 to .44.0.0. I don't know how to handle transition. Sailfish-office needs to be recompiled against this new library, but I don't know how to include it into SDK.

Besides, installing 0.24.5 in my phone, ignoring dependencies and making a link to .44.0.0 named .43.0.0, I've tested it and it works fine for various PDFs on my phone, including the reported PDFs that crashes before.